### PR TITLE
[Dev → Test] EIP-712 signature verification for UnifiedID registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ UnifiedIDRegistry is a smart contract that provides a secure and efficient way t
 - **Registrar Management**: Contract owner can add or remove registrars dynamically
 - **Bidirectional Lookup**: Query UnifiedID by wallet address or wallet by UnifiedID
 - **Format Validation**: Enforces strict format rules for UnifiedIDs (lowercase alphanumeric, 4-16 characters)
-- **EIP-712 Support**: Built-in support for EIP-712 typed structured data hashing and signing
+- **EIP-712 Support**: Built-in support for EIP-712 typed structured data hashing and signing with nonce tracking for replay protection
 - **Reentrancy Protection**: Uses OpenZeppelin's ReentrancyGuard for security
 - **Multi-Network Support**: Deployable to Polygon, Ethereum Sepolia, Base Sepolia, BNB Chain (coming soon), and more
 
@@ -327,16 +327,31 @@ async function example() {
   - `wallet`: The wallet address to query
 - **Returns**: The UnifiedID string associated with the wallet, or empty string if wallet has no ID
 
+#### `getNonce(address wallet) → uint256`
+- **Access**: Public view
+- **Description**: Gets the current nonce for a wallet address
+- **Parameters**: 
+  - `wallet`: The wallet address to query
+- **Returns**: The current nonce value (starts at 0 for new addresses)
+- **Use Case**: Used for signature replay protection in EIP-712 based registration flows
+
 #### `domainSeparator() → bytes32`
 - **Access**: Public view
 - **Description**: Returns the EIP-712 domain separator for use in off-chain signature verification
 - **Returns**: The domain separator bytes32 value
 - **Use Case**: Enables off-chain applications to verify typed structured data signatures according to EIP-712 standard
 
+#### `getUnifiedIdTypehash() → bytes32`
+- **Access**: Public view
+- **Description**: Returns the EIP-712 typehash for UnifiedID registration
+- **Returns**: The typehash bytes32 value for "UnifiedIdRegistration(address wallet,string unifiedId,uint256 nonce)"
+- **Use Case**: Enables off-chain applications to construct typed structured data messages for signature verification
+
 ### Public State Variables
 
 - `registrarCount` (uint256): Total count of active registrars
 - `totalIDs` (uint256): Total number of UnifiedIDs created
+- `nonces` (mapping(address => uint256)): Mapping from wallet address to current nonce for signature replay protection
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ UnifiedIDRegistry is a smart contract that provides a secure and efficient way t
 - **Registrar Management**: Contract owner can add or remove registrars dynamically
 - **Bidirectional Lookup**: Query UnifiedID by wallet address or wallet by UnifiedID
 - **Format Validation**: Enforces strict format rules for UnifiedIDs (lowercase alphanumeric, 4-16 characters)
+- **EIP-712 Support**: Built-in support for EIP-712 typed structured data hashing and signing
 - **Reentrancy Protection**: Uses OpenZeppelin's ReentrancyGuard for security
 - **Multi-Network Support**: Deployable to Polygon, Ethereum Sepolia, Base Sepolia, BNB Chain (coming soon), and more
 
@@ -325,6 +326,12 @@ async function example() {
 - **Parameters**: 
   - `wallet`: The wallet address to query
 - **Returns**: The UnifiedID string associated with the wallet, or empty string if wallet has no ID
+
+#### `domainSeparator() → bytes32`
+- **Access**: Public view
+- **Description**: Returns the EIP-712 domain separator for use in off-chain signature verification
+- **Returns**: The domain separator bytes32 value
+- **Use Case**: Enables off-chain applications to verify typed structured data signatures according to EIP-712 standard
 
 ### Public State Variables
 

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ npx hardhat run scripts/manage-registrars.js --network baseSepolia
 This interactive script allows you to:
 - Add new registrars (owner only)
 - Remove existing registrars (owner only)
-- List all current registrars
 - Check if an address is a registrar
+- Get the total count of registrars
 
 ### Programmatic Usage
 
@@ -410,15 +410,11 @@ async function example() {
 - **Description**: Checks if an address is an authorized registrar
 - **Returns**: `true` if the address is a registrar, `false` otherwise
 
-#### `getRegistrars() → address[]`
-- **Access**: Public view
-- **Description**: Gets all registrar addresses
-- **Returns**: Array of all registrar addresses
-
 #### `getRegistrarCount() → uint256`
 - **Access**: Public view
 - **Description**: Gets the total number of active registrars
 - **Returns**: The count of active registrars
+- **Note**: The contract uses a simplified storage design without array enumeration for gas efficiency. Use `isRegistrar()` to check individual addresses.
 
 ### UnifiedID Management Functions
 
@@ -596,8 +592,9 @@ The contract supports three registration methods:
 
 4. **Gas Optimization**:
    - Contract uses optimizer with 200 runs
-   - Efficient storage patterns
+   - Efficient storage patterns (simplified registrar storage without array enumeration)
    - Minimal external calls
+   - Registrar management uses mapping-only storage for reduced gas costs
 
 5. **Reentrancy Protection**:
    - All state-changing functions use `nonReentrant` modifier

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A decentralized registry system for managing UnifiedID mappings to wallet addres
 
 UnifiedIDRegistry is a smart contract that provides a secure and efficient way to map human-readable UnifiedIDs to blockchain wallet addresses. The contract uses a multi-registrar architecture where multiple authorized registrars can create new UnifiedID entries, ensuring controlled and verified identity creation.
 
+The contract includes comprehensive EIP-712 support for typed structured data signing, enabling secure, gasless registration flows where wallets can sign registration requests off-chain, and registrars can verify and process them on-chain. Nonce tracking prevents signature replay attacks, ensuring each signature can only be used once.
+
 ### Key Features
 
 - **Secure Identity Mapping**: Map UnifiedIDs to primary wallet addresses with on-chain verification
@@ -113,7 +115,15 @@ npm run test
 npm run coverage
 ```
 
-The test suite includes deployment tests, registrar management tests, UnifiedID creation tests, and comprehensive edge case coverage.
+The test suite includes:
+- Deployment tests
+- EIP-712 infrastructure tests (domain separator, typehash, hash computation)
+- Nonce tracking tests
+- Signature verification error and event tests
+- Registrar management tests
+- UnifiedID creation tests
+- Comprehensive edge case coverage
+- Integration tests with EIP-712 signature verification
 
 ## Deployment
 
@@ -169,6 +179,76 @@ npx hardhat verify --network baseSepolia <CONTRACT_ADDRESS> <INITIAL_REGISTRAR_A
 Replace:
 - `<CONTRACT_ADDRESS>` with your deployed contract address
 - `<INITIAL_REGISTRAR_ADDRESS>` with the initial registrar address used during deployment
+
+## EIP-712 Signature-Based Registration
+
+The contract supports EIP-712 typed structured data signing for secure, gasless registration flows. Here's how to use it:
+
+### Off-Chain Signature Generation
+
+```javascript
+const { ethers } = require("ethers");
+
+async function signRegistration(wallet, contractAddress, chainId, walletAddress, unifiedId, nonce) {
+  const domain = {
+    name: "UnifiedIDRegistry",
+    version: "1",
+    chainId: chainId,
+    verifyingContract: contractAddress
+  };
+  
+  const types = {
+    UnifiedIdRegistration: [
+      { name: "wallet", type: "address" },
+      { name: "unifiedId", type: "string" },
+      { name: "nonce", type: "uint256" }
+    ]
+  };
+  
+  const value = {
+    wallet: walletAddress,
+    unifiedId: unifiedId,
+    nonce: nonce
+  };
+  
+  // Sign with MetaMask or other EIP-712 compatible wallet
+  const signature = await wallet._signTypedData(domain, types, value);
+  return signature;
+}
+
+// Example usage
+const wallet = new ethers.Wallet("PRIVATE_KEY");
+const contractAddress = "0x..."; // Your contract address
+const chainId = 84532; // Base Sepolia
+const walletToRegister = "0x...";
+const unifiedId = "alice123";
+
+// Get current nonce from contract
+const registry = new ethers.Contract(contractAddress, abi, provider);
+const nonce = await registry.getNonce(walletToRegister);
+
+// Generate signature
+const signature = await signRegistration(
+  wallet,
+  contractAddress,
+  chainId,
+  walletToRegister,
+  unifiedId,
+  nonce
+);
+
+// Verify hash matches contract computation
+const contractHash = await registry.getRegistrationHash(
+  walletToRegister,
+  unifiedId,
+  nonce
+);
+console.log("Hash to sign:", contractHash);
+```
+
+### Verifying Signatures
+
+The contract's `getRegistrationHash()` function returns the exact hash that should be signed. This hash can be verified off-chain or used in a future signature-based registration function.
 
 ## Usage Examples
 
@@ -241,6 +321,23 @@ async function example() {
   const unifiedId = await registry.getUnifiedIdByWallet(
     "0x0000000000000000000000000000000000000000"
   );
+
+  // EIP-712: Get registration hash for signature-based registration
+  const wallet = "0x0000000000000000000000000000000000000000";
+  const unifiedIdToRegister = "alice123";
+  const nonce = await registry.getNonce(wallet);
+  const registrationHash = await registry.getRegistrationHash(
+    wallet,
+    unifiedIdToRegister,
+    nonce
+  );
+  console.log("Registration hash:", registrationHash);
+
+  // Get domain separator and typehash for EIP-712 signing
+  const domainSeparator = await registry.domainSeparator();
+  const typehash = await registry.getUnifiedIdTypehash();
+  console.log("Domain separator:", domainSeparator);
+  console.log("Typehash:", typehash);
 }
 ```
 
@@ -347,6 +444,17 @@ async function example() {
 - **Returns**: The typehash bytes32 value for "UnifiedIdRegistration(address wallet,string unifiedId,uint256 nonce)"
 - **Use Case**: Enables off-chain applications to construct typed structured data messages for signature verification
 
+#### `getRegistrationHash(address wallet, string calldata unifiedId, uint256 nonce) → bytes32`
+- **Access**: Public view
+- **Description**: Computes the EIP-712 hash for a registration request
+- **Parameters**: 
+  - `wallet`: The wallet address to be registered
+  - `unifiedId`: The UnifiedID to be registered
+  - `nonce`: The nonce to use (should match current nonce for wallet)
+- **Returns**: The digest that needs to be signed by the wallet
+- **Use Case**: Enables frontend/backend applications to compute the exact hash that wallets need to sign for EIP-712 based registration flows
+- **Example**: Use this hash with `signTypedData` in MetaMask or other EIP-712 compatible wallets
+
 ### Public State Variables
 
 - `registrarCount` (uint256): Total count of active registrars
@@ -358,6 +466,23 @@ async function example() {
 - `UnifiedIDCreated(string indexed unifiedId, address indexed primaryWallet, uint256 timestamp)`: Emitted when a new UnifiedID is created
 - `RegistrarAdded(address indexed registrar, address indexed addedBy, uint256 timestamp)`: Emitted when a new registrar is added
 - `RegistrarRemoved(address indexed registrar, address indexed removedBy, uint256 timestamp)`: Emitted when a registrar is removed
+- `NonceConsumed(address indexed wallet, uint256 nonce)`: Emitted when a wallet's nonce is consumed during successful signature-based registration
+
+### Custom Errors
+
+- `OnlyRegistrar()`: Thrown when a function is called by an address that is not an authorized registrar
+- `UnifiedIdTooShort()`: Thrown when a UnifiedID is too short (less than minimum length)
+- `UnifiedIdTooLong()`: Thrown when a UnifiedID is too long (exceeds maximum length)
+- `InvalidUnifiedIdFormat()`: Thrown when a UnifiedID format is invalid
+- `UnifiedIdAlreadyTaken()`: Thrown when attempting to create a UnifiedID that already exists
+- `InvalidPrimaryWallet()`: Thrown when the primary wallet address is invalid (zero address)
+- `WalletAlreadyHasId()`: Thrown when a wallet already has an associated UnifiedID
+- `UnifiedIdDoesNotExist()`: Thrown when querying a UnifiedID that does not exist
+- `InvalidRegistrarAddress()`: Thrown when attempting to set an invalid registrar address (zero address)
+- `RegistrarAlreadyAdded()`: Thrown when attempting to add an address that is already registered as a registrar
+- `RegistrarDoesNotExist()`: Thrown when attempting to remove a registrar that does not currently exist
+- `InvalidSignature()`: Thrown when signature verification fails - recovered signer doesn't match expected wallet
+- `SignatureExpired()`: Thrown when signature deadline has passed (reserved for future use)
 
 ## Security Considerations
 
@@ -392,6 +517,13 @@ async function example() {
 5. **Reentrancy Protection**:
    - All state-changing functions use `nonReentrant` modifier
    - Follows checks-effects-interactions pattern
+
+6. **EIP-712 Signature Verification**:
+   - Contract supports EIP-712 typed structured data signing
+   - Nonce tracking prevents signature replay attacks
+   - Domain separator and typehash are exposed for off-chain verification
+   - Use `getRegistrationHash()` to compute the exact hash that needs to be signed
+   - Always verify signatures match the expected wallet address before processing
 
 
 ## Available Scripts

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A decentralized registry system for managing UnifiedID mappings to wallet addres
 
 UnifiedIDRegistry is a smart contract that provides a secure and efficient way to map human-readable UnifiedIDs to blockchain wallet addresses. The contract uses a multi-registrar architecture where multiple authorized registrars can create new UnifiedID entries, ensuring controlled and verified identity creation.
 
+**Version 1.0.0**: All registrations now require EIP-712 signatures for enhanced security and user consent. The legacy `createUnifiedID` function (without signature requirement) has been removed.
+
 The contract includes comprehensive EIP-712 support for typed structured data signing, enabling secure, gasless registration flows where wallets can sign registration requests off-chain, and registrars can verify and process them on-chain. Nonce tracking prevents signature replay attacks, ensuring each signature can only be used once.
 
 ### Key Features
@@ -16,7 +18,8 @@ The contract includes comprehensive EIP-712 support for typed structured data si
 - **Bidirectional Lookup**: Query UnifiedID by wallet address or wallet by UnifiedID
 - **Format Validation**: Enforces strict format rules for UnifiedIDs (lowercase alphanumeric, 4-16 characters)
 - **EIP-712 Support**: Built-in support for EIP-712 typed structured data hashing and signing with nonce tracking for replay protection
-- **Multiple Registration Paths**: Supports three registration methods - direct registrar creation, registrar-submitted with user signature, and self-service registration
+- **Signature-Based Registration**: All registrations require EIP-712 signatures for enhanced security and user consent
+- **Multiple Registration Paths**: Supports two signature-based registration methods - registrar-submitted with user signature, and self-service registration
 - **Reentrancy Protection**: Uses OpenZeppelin's ReentrancyGuard for security
 - **Multi-Network Support**: Deployable to Polygon, Ethereum Sepolia, Base Sepolia, BNB Chain (coming soon), and more
 
@@ -122,10 +125,11 @@ The test suite includes:
 - Nonce tracking tests
 - Signature verification error and event tests
 - Registrar management tests
-- UnifiedID creation tests (direct, registrar-submitted with signature, self-service)
+- UnifiedID creation tests (registrar-submitted with signature, self-service)
 - Signature-based registration tests (`createUnifiedIDByRegistrar` and `createUnifiedIDSelf`)
 - Comprehensive edge case coverage
 - Integration tests with EIP-712 signature verification
+- Tests verifying legacy `createUnifiedID` function no longer exists
 
 ## Deployment
 
@@ -184,28 +188,30 @@ Replace:
 
 ## Registration Methods
 
-The contract provides three registration methods to suit different use cases:
+The contract provides two signature-based registration methods to suit different use cases. **All registrations require EIP-712 signatures** for enhanced security and user consent.
 
-### 1. Direct Registration (`createUnifiedID`)
-**Use Case**: Traditional registration where registrar creates UnifiedIDs directly
-- **Who calls**: Authorized registrar
-- **Signature required**: No
-- **Gas payer**: Registrar
-- **Best for**: Centralized registration systems, admin-controlled registrations
-
-### 2. Registrar-Submitted Registration (`createUnifiedIDByRegistrar`)
+### 1. Registrar-Submitted Registration (`createUnifiedIDByRegistrar`)
 **Use Case**: Gasless registration where user signs off-chain, registrar submits on-chain
 - **Who calls**: Authorized registrar
-- **Signature required**: Yes (from user)
+- **Signature required**: Yes (EIP-712 signature from user)
 - **Gas payer**: Registrar
-- **Best for**: User-initiated registrations where registrar pays gas fees, relayer patterns
+- **Best for**: User-initiated registrations where registrar pays gas fees, relayer patterns, backend-initiated registrations
 
-### 3. Self-Service Registration (`createUnifiedIDSelf`)
+### 2. Self-Service Registration (`createUnifiedIDSelf`)
 **Use Case**: Users register themselves directly
 - **Who calls**: User (any address)
-- **Signature required**: Yes (from user)
+- **Signature required**: Yes (EIP-712 signature from user)
 - **Gas payer**: User
-- **Best for**: Decentralized registration, user-controlled registrations, DApp integrations
+- **Best for**: Decentralized registration, user-controlled registrations, DApp integrations, frontend-initiated registrations
+
+### Breaking Change Notice
+
+**Version 1.0.0**: The legacy `createUnifiedID` function (without signature requirement) has been removed. All registrations now require EIP-712 signatures for enhanced security and user consent.
+
+**Migration Guide**:
+- **Backend/Relayer**: Collect user EIP-712 signatures before calling `createUnifiedIDByRegistrar`
+- **Frontend**: Use `createUnifiedIDSelf` for direct user registration with signature
+- **Existing Integrations**: Update all code that calls `createUnifiedID()` to use signature-based functions
 
 ## EIP-712 Signature-Based Registration
 
@@ -288,19 +294,14 @@ Both functions verify the signature matches the expected wallet and current nonc
 
 The project includes several Hardhat tasks for interacting with the contract:
 
-#### 1. Create a UnifiedID
+#### 1. Create a UnifiedID (Signature Required)
 
-```bash
-npx hardhat create-id \
-  --unifiedid "alice123" \
-  --wallet 0x0000000000000000000000000000000000000000 \
-  --network baseSepolia
-```
+**Note**: All registrations now require EIP-712 signatures. Use the signature-based registration functions:
 
-This will:
-- Create a new UnifiedID "alice123" mapped to the specified wallet
-- Display transaction hash and gas usage
-- Require the signer to be an authorized registrar
+- For registrar-submitted registration: Use `createUnifiedIDByRegistrar` with user signature
+- For self-service registration: Use `createUnifiedIDSelf` with user signature
+
+See the "EIP-712 Signature-Based Registration" section below for signature generation examples.
 
 #### 2. Get UnifiedID Details
 
@@ -418,22 +419,7 @@ async function example() {
 
 ### UnifiedID Management Functions
 
-The contract supports three registration methods:
-
-#### `createUnifiedID(string calldata unifiedId, address primaryWallet)`
-- **Access**: Registrar only
-- **Description**: Creates a new UnifiedID and maps it to a primary wallet (no signature required)
-- **Parameters**: 
-  - `unifiedId`: The UnifiedID string to create (4-16 characters, lowercase alphanumeric)
-  - `primaryWallet`: The primary wallet address to associate with the UnifiedID
-- **Requirements**: 
-  - Caller must be an authorized registrar
-  - UnifiedID must not already exist
-  - UnifiedID must be valid format (lowercase a-z, 0-9, 4-16 chars)
-  - Wallet must not already have a UnifiedID
-  - Wallet address must not be zero address
-- **Events**: Emits `UnifiedIDCreated` event
-- **Use Case**: Direct registration by registrar without user signature (traditional flow)
+The contract supports two signature-based registration methods. **All registrations require EIP-712 signatures**.
 
 #### `createUnifiedIDByRegistrar(string calldata unifiedId, address primaryWallet, bytes calldata signature)`
 - **Access**: Registrar only
@@ -600,16 +586,18 @@ The contract supports three registration methods:
    - All state-changing functions use `nonReentrant` modifier
    - Follows checks-effects-interactions pattern
 
-6. **EIP-712 Signature Verification**:
+6. **EIP-712 Signature Verification** (Required for All Registrations):
+   - **All registrations require EIP-712 signatures** - the legacy `createUnifiedID` function has been removed
    - Contract supports EIP-712 typed structured data signing
    - Nonce tracking prevents signature replay attacks
    - Domain separator and typehash are exposed for off-chain verification
    - Use `getRegistrationHash()` to compute the exact hash that needs to be signed
    - Always verify signatures match the expected wallet address before processing
    - Two signature-based registration functions available:
-     - `createUnifiedIDByRegistrar`: For registrar-submitted registrations
-     - `createUnifiedIDSelf`: For self-service registrations
+     - `createUnifiedIDByRegistrar`: For registrar-submitted registrations (registrar pays gas)
+     - `createUnifiedIDSelf`: For self-service registrations (user pays gas)
    - Both functions increment nonce only on successful registration
+   - **Breaking Change**: Version 1.0.0 removed the legacy `createUnifiedID` function without signature requirement
 
 
 ## Available Scripts

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The contract includes comprehensive EIP-712 support for typed structured data si
 - **Bidirectional Lookup**: Query UnifiedID by wallet address or wallet by UnifiedID
 - **Format Validation**: Enforces strict format rules for UnifiedIDs (lowercase alphanumeric, 4-16 characters)
 - **EIP-712 Support**: Built-in support for EIP-712 typed structured data hashing and signing with nonce tracking for replay protection
+- **Multiple Registration Paths**: Supports three registration methods - direct registrar creation, registrar-submitted with user signature, and self-service registration
 - **Reentrancy Protection**: Uses OpenZeppelin's ReentrancyGuard for security
 - **Multi-Network Support**: Deployable to Polygon, Ethereum Sepolia, Base Sepolia, BNB Chain (coming soon), and more
 
@@ -121,7 +122,8 @@ The test suite includes:
 - Nonce tracking tests
 - Signature verification error and event tests
 - Registrar management tests
-- UnifiedID creation tests
+- UnifiedID creation tests (direct, registrar-submitted with signature, self-service)
+- Signature-based registration tests (`createUnifiedIDByRegistrar` and `createUnifiedIDSelf`)
 - Comprehensive edge case coverage
 - Integration tests with EIP-712 signature verification
 
@@ -179,6 +181,31 @@ npx hardhat verify --network baseSepolia <CONTRACT_ADDRESS> <INITIAL_REGISTRAR_A
 Replace:
 - `<CONTRACT_ADDRESS>` with your deployed contract address
 - `<INITIAL_REGISTRAR_ADDRESS>` with the initial registrar address used during deployment
+
+## Registration Methods
+
+The contract provides three registration methods to suit different use cases:
+
+### 1. Direct Registration (`createUnifiedID`)
+**Use Case**: Traditional registration where registrar creates UnifiedIDs directly
+- **Who calls**: Authorized registrar
+- **Signature required**: No
+- **Gas payer**: Registrar
+- **Best for**: Centralized registration systems, admin-controlled registrations
+
+### 2. Registrar-Submitted Registration (`createUnifiedIDByRegistrar`)
+**Use Case**: Gasless registration where user signs off-chain, registrar submits on-chain
+- **Who calls**: Authorized registrar
+- **Signature required**: Yes (from user)
+- **Gas payer**: Registrar
+- **Best for**: User-initiated registrations where registrar pays gas fees, relayer patterns
+
+### 3. Self-Service Registration (`createUnifiedIDSelf`)
+**Use Case**: Users register themselves directly
+- **Who calls**: User (any address)
+- **Signature required**: Yes (from user)
+- **Gas payer**: User
+- **Best for**: Decentralized registration, user-controlled registrations, DApp integrations
 
 ## EIP-712 Signature-Based Registration
 
@@ -248,7 +275,12 @@ console.log("Hash to sign:", contractHash);
 
 ### Verifying Signatures
 
-The contract's `getRegistrationHash()` function returns the exact hash that should be signed. This hash can be verified off-chain or used in a future signature-based registration function.
+The contract's `getRegistrationHash()` function returns the exact hash that should be signed. This hash can be verified off-chain and used with the signature-based registration functions:
+
+- **`createUnifiedIDByRegistrar`**: For registrar-submitted registrations with user signatures
+- **`createUnifiedIDSelf`**: For self-service registrations where users submit their own signatures
+
+Both functions verify the signature matches the expected wallet and current nonce, providing replay protection.
 
 ## Usage Examples
 
@@ -338,6 +370,20 @@ async function example() {
   const typehash = await registry.getUnifiedIdTypehash();
   console.log("Domain separator:", domainSeparator);
   console.log("Typehash:", typehash);
+
+  // Example: Self-service registration with signature
+  const wallet = "0x..."; // User's wallet
+  const unifiedIdToRegister = "alice123";
+  const nonce = await registry.getNonce(wallet);
+  
+  // User signs the registration (off-chain)
+  const signature = await signRegistration(walletSigner, registry, wallet, unifiedIdToRegister, nonce);
+  
+  // User submits their own registration
+  await registry.connect(walletSigner).createUnifiedIDSelf(unifiedIdToRegister, signature);
+  
+  // OR: Registrar submits on behalf of user
+  // await registry.connect(registrar).createUnifiedIDByRegistrar(unifiedIdToRegister, wallet, signature);
 }
 ```
 
@@ -376,9 +422,11 @@ async function example() {
 
 ### UnifiedID Management Functions
 
+The contract supports three registration methods:
+
 #### `createUnifiedID(string calldata unifiedId, address primaryWallet)`
 - **Access**: Registrar only
-- **Description**: Creates a new UnifiedID and maps it to a primary wallet
+- **Description**: Creates a new UnifiedID and maps it to a primary wallet (no signature required)
 - **Parameters**: 
   - `unifiedId`: The UnifiedID string to create (4-16 characters, lowercase alphanumeric)
   - `primaryWallet`: The primary wallet address to associate with the UnifiedID
@@ -389,6 +437,43 @@ async function example() {
   - Wallet must not already have a UnifiedID
   - Wallet address must not be zero address
 - **Events**: Emits `UnifiedIDCreated` event
+- **Use Case**: Direct registration by registrar without user signature (traditional flow)
+
+#### `createUnifiedIDByRegistrar(string calldata unifiedId, address primaryWallet, bytes calldata signature)`
+- **Access**: Registrar only
+- **Description**: Creates a new UnifiedID via registrar with user signature verification
+- **Parameters**: 
+  - `unifiedId`: The UnifiedID string to create (4-16 characters, lowercase alphanumeric)
+  - `primaryWallet`: The primary wallet address to associate with the UnifiedID
+  - `signature`: The EIP-712 signature from `primaryWallet` authorizing this registration
+- **Requirements**: 
+  - Caller must be an authorized registrar
+  - Signature must be valid EIP-712 signature from `primaryWallet`
+  - Signature must match current nonce for `primaryWallet`
+  - UnifiedID must not already exist
+  - UnifiedID must be valid format (lowercase a-z, 0-9, 4-16 chars)
+  - Wallet must not already have a UnifiedID
+  - Wallet address must not be zero address
+- **Events**: Emits `UnifiedIDCreated` and `NonceConsumed` events
+- **Use Case**: Gasless registration flow where user signs off-chain, registrar submits on-chain
+- **Security**: Nonce is incremented after successful registration to prevent signature replay
+
+#### `createUnifiedIDSelf(string calldata unifiedId, bytes calldata signature)`
+- **Access**: Public (any address)
+- **Description**: Creates a new UnifiedID by the user themselves with signature verification
+- **Parameters**: 
+  - `unifiedId`: The UnifiedID string to create (4-16 characters, lowercase alphanumeric)
+  - `signature`: The EIP-712 signature from `msg.sender` authorizing this registration
+- **Requirements**: 
+  - Signature must be valid EIP-712 signature from `msg.sender`
+  - Signature must match current nonce for `msg.sender`
+  - UnifiedID must not already exist
+  - UnifiedID must be valid format (lowercase a-z, 0-9, 4-16 chars)
+  - Wallet (`msg.sender`) must not already have a UnifiedID
+- **Events**: Emits `UnifiedIDCreated` and `NonceConsumed` events
+- **Use Case**: Self-service registration where users register themselves directly
+- **Security**: Nonce is incremented after successful registration to prevent signature replay
+- **Note**: No registrar required - any address can register themselves
 
 ### View Functions
 
@@ -524,6 +609,10 @@ async function example() {
    - Domain separator and typehash are exposed for off-chain verification
    - Use `getRegistrationHash()` to compute the exact hash that needs to be signed
    - Always verify signatures match the expected wallet address before processing
+   - Two signature-based registration functions available:
+     - `createUnifiedIDByRegistrar`: For registrar-submitted registrations
+     - `createUnifiedIDSelf`: For self-service registrations
+   - Both functions increment nonce only on successful registration
 
 
 ## Available Scripts

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -31,6 +31,9 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
     /// @dev Total number of UnifiedIDs created
     uint256 public totalIDs;
 
+    /// @dev Mapping from wallet address to current nonce for signature replay protection
+    mapping(address => uint256) public nonces;
+
     // ============ Structs ============
 
     /**
@@ -134,6 +137,10 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
 
     /// @dev Maximum length for a UnifiedID (16 characters)
     uint256 private constant MAX_UNIFIED_ID_LENGTH = 16;  // 
+
+    /// @dev EIP-712 typehash for UnifiedID registration
+    bytes32 private constant UNIFIED_ID_TYPEHASH =
+        keccak256("UnifiedIdRegistration(address wallet,string unifiedId,uint256 nonce)");
 
     // ============ Modifiers ============
 
@@ -346,12 +353,30 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
     }
 
     /**
+     * @dev Gets the current nonce for a wallet address
+     * @param wallet The wallet address to query
+     * @return The current nonce value
+     */
+    function getNonce(address wallet) external view returns (uint256) {
+        return nonces[wallet];
+    }
+
+    /**
      * @dev Returns the EIP-712 domain separator
      * @return The domain separator bytes32 value
      * @notice This function exposes the domain separator for use in off-chain signature verification
      */
     function domainSeparator() external view returns (bytes32) {
         return _domainSeparatorV4();
+    }
+
+    /**
+     * @dev Returns the EIP-712 typehash for UnifiedID registration
+     * @return The typehash bytes32 value
+     * @notice This function exposes the typehash for use in off-chain signature verification
+     */
+    function getUnifiedIdTypehash() external pure returns (bytes32) {
+        return UNIFIED_ID_TYPEHASH;
     }
 
     // ============ Internal Functions ============

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -235,6 +235,38 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         _createUnifiedID(unifiedId, primaryWallet);
     }
 
+    /**
+     * @dev Creates a new UnifiedID by the user themselves with signature verification
+     * @param unifiedId The UnifiedID string to create
+     * @param signature The EIP-712 signature from msg.sender authorizing this registration
+     * @notice Callable by any address for themselves, requires valid signature
+     */
+    function createUnifiedIDSelf(
+        string calldata unifiedId,
+        bytes calldata signature
+    ) external nonReentrant {
+        address wallet = msg.sender;
+
+        uint256 nonce = nonces[wallet];
+
+        bytes32 digest = _hashUnifiedIdMessage(
+            wallet,
+            unifiedId,
+            nonce
+        );
+
+        address signer = digest.recover(signature);
+        if (signer != wallet) {
+            revert InvalidSignature();
+        }
+
+        // Consume nonce only on success
+        nonces[wallet] = nonce + 1;
+        emit NonceConsumed(wallet, nonce);
+
+        _createUnifiedID(unifiedId, wallet);
+    }
+
     // ============ Registrar Management Functions ============
 
     /**

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -9,8 +9,9 @@ import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 /**
  * @title UnifiedIDRegistry
  * @dev Registry contract for managing UnifiedID mappings to wallet addresses
- * @notice This contract allows a relayer to create UnifiedIDs and map them to primary wallets
+ * @notice This contract allows registrars or users to create UnifiedIDs with EIP-712 signature verification
  * @notice Supports EIP-712 for typed structured data hashing and signing
+ * @custom:version 1.0.0 - EIP-712 signature verification required for all registrations
  */
 contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
     // ============ Libraries ============
@@ -185,19 +186,6 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
     }
 
     // ============ External Functions ============
-
-    /**
-     * @dev Creates a new UnifiedID and maps it to a primary wallet
-     * @param unifiedId The UnifiedID string to create
-     * @param primaryWallet The primary wallet address to associate with the UnifiedID
-     * @notice Only callable by authorized registrars, non-reentrant
-     */
-    function createUnifiedID(
-        string calldata unifiedId,
-        address primaryWallet
-    ) external onlyRegistrar nonReentrant {
-        _createUnifiedID(unifiedId, primaryWallet);
-    }
 
     /**
      * @dev Creates a new UnifiedID via registrar with user signature verification

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -22,9 +22,6 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
     /// @dev Mapping to determine whether an address is an active registrar authorized to create UnifiedIDs
     mapping(address => bool) private _isRegistrar;
 
-    /// @dev Array containing every registrar address ever authorized, enabling enumeration of current registrars
-    address[] private _registrarList;
-
     /// @dev Total count of active registrar addresses for quick external access
     uint256 public registrarCount;
 
@@ -182,7 +179,6 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         }
 
         _isRegistrar[_initialRegistrar] = true;
-        _registrarList.push(_initialRegistrar);
         registrarCount = 1;
 
         emit RegistrarAdded(_initialRegistrar, msg.sender, block.timestamp);
@@ -284,7 +280,6 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         }
 
         _isRegistrar[registrar] = true;
-        _registrarList.push(registrar);
 
         unchecked {
             registrarCount++;
@@ -305,14 +300,6 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
 
         _isRegistrar[registrar] = false;
 
-        for (uint256 i = 0; i < _registrarList.length; i++) {
-            if (_registrarList[i] == registrar) {
-                _registrarList[i] = _registrarList[_registrarList.length - 1];
-                _registrarList.pop();
-                break;
-            }
-        }
-
         unchecked {
             registrarCount--;
         }
@@ -327,14 +314,6 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
      */
     function isRegistrar(address account) external view returns (bool) {
         return _isRegistrar[account];
-    }
-
-    /**
-     * @dev Gets all registrar addresses
-     * @return Array of all registrar addresses
-     */
-    function getRegistrars() external view returns (address[] memory) {
-        return _registrarList;
     }
 
     /**

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -200,42 +200,7 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         string calldata unifiedId,
         address primaryWallet
     ) external onlyRegistrar nonReentrant {
-        // Validate UnifiedID format
-        _validateUnifiedIdFormat(unifiedId);
-
-        // Check if UnifiedID already exists
-        if (_unifiedIdExists[unifiedId]) {
-            revert UnifiedIdAlreadyTaken();
-        }
-
-        // Validate primary wallet address
-        if (primaryWallet == address(0)) {
-            revert InvalidPrimaryWallet();
-        }
-
-        // Check if wallet already has a UnifiedID
-        bytes memory existingId = bytes(walletToUnifiedId[primaryWallet]);
-        if (existingId.length > 0) {
-            revert WalletAlreadyHasId();
-        }
-
-        // Create the UnifiedID entry
-        uint256 timestamp = block.timestamp;
-        registry[unifiedId] = UnifiedID({
-            primaryWallet: primaryWallet,
-            createdAt: timestamp
-        });
-
-        // Update mappings
-        walletToUnifiedId[primaryWallet] = unifiedId;
-        _unifiedIdExists[unifiedId] = true;
-
-        unchecked {
-            totalIDs++;
-        }
-
-        // Emit event
-        emit UnifiedIDCreated(unifiedId, primaryWallet, timestamp);
+        _createUnifiedID(unifiedId, primaryWallet);
     }
 
     // ============ Registrar Management Functions ============
@@ -411,6 +376,53 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
     }
 
     // ============ Internal Functions ============
+
+    /**
+     * @dev Internal function to create a UnifiedID - shared by both registration paths
+     * @param unifiedId The UnifiedID string to create
+     * @param primaryWallet The primary wallet address to associate
+     */
+    function _createUnifiedID(
+        string calldata unifiedId,
+        address primaryWallet
+    ) internal {
+        // Validate UnifiedID format
+        _validateUnifiedIdFormat(unifiedId);
+
+        // Check if UnifiedID already exists
+        if (_unifiedIdExists[unifiedId]) {
+            revert UnifiedIdAlreadyTaken();
+        }
+
+        // Validate primary wallet address
+        if (primaryWallet == address(0)) {
+            revert InvalidPrimaryWallet();
+        }
+
+        // Check if wallet already has a UnifiedID
+        bytes memory existingId = bytes(walletToUnifiedId[primaryWallet]);
+        if (existingId.length > 0) {
+            revert WalletAlreadyHasId();
+        }
+
+        // Create the UnifiedID entry
+        uint256 timestamp = block.timestamp;
+        registry[unifiedId] = UnifiedID({
+            primaryWallet: primaryWallet,
+            createdAt: timestamp
+        });
+
+        // Update mappings
+        walletToUnifiedId[primaryWallet] = unifiedId;
+        _unifiedIdExists[unifiedId] = true;
+
+        unchecked {
+            totalIDs++;
+        }
+
+        // Emit event
+        emit UnifiedIDCreated(unifiedId, primaryWallet, timestamp);
+    }
 
     /**
      * @dev Builds the EIP-712 typed data hash for UnifiedID registration

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -395,7 +395,46 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         return UNIFIED_ID_TYPEHASH;
     }
 
+    /**
+     * @dev Computes the EIP-712 hash for a registration request (for frontend/backend use)
+     * @param wallet The wallet address to be registered
+     * @param unifiedId The UnifiedID to be registered
+     * @param nonce The nonce to use (should match current nonce for wallet)
+     * @return The digest that needs to be signed by the wallet
+     */
+    function getRegistrationHash(
+        address wallet,
+        string calldata unifiedId,
+        uint256 nonce
+    ) external view returns (bytes32) {
+        return _hashUnifiedIdMessage(wallet, unifiedId, nonce);
+    }
+
     // ============ Internal Functions ============
+
+    /**
+     * @dev Builds the EIP-712 typed data hash for UnifiedID registration
+     * @param wallet The wallet address being registered
+     * @param unifiedId The UnifiedID string being registered
+     * @param nonce The current nonce for the wallet
+     * @return The EIP-712 compliant digest ready for signature verification
+     */
+    function _hashUnifiedIdMessage(
+        address wallet,
+        string calldata unifiedId,
+        uint256 nonce
+    ) internal view returns (bytes32) {
+        return _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    UNIFIED_ID_TYPEHASH,
+                    wallet,
+                    keccak256(bytes(unifiedId)),
+                    nonce
+                )
+            )
+        );
+    }
 
     /**
      * @dev Validates the format of a UnifiedID string

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -95,6 +95,16 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         uint256 timestamp
     );
 
+    /**
+     * @dev Emitted when a wallet's nonce is consumed during successful registration
+     * @param wallet The wallet address whose nonce was consumed (indexed)
+     * @param nonce The nonce value that was consumed
+     */
+    event NonceConsumed(
+        address indexed wallet,
+        uint256 nonce
+    );
+
     // ============ Custom Errors ============
 
     /// @dev Thrown when a function is called by an address that is not an authorized registrar
@@ -129,6 +139,12 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
 
     /// @dev Thrown when attempting to remove a registrar that does not currently exist
     error RegistrarDoesNotExist();
+
+    /// @dev Thrown when signature verification fails - recovered signer doesn't match expected wallet
+    error InvalidSignature();
+
+    /// @dev Thrown when signature deadline has passed (reserved for future use)
+    error SignatureExpired();
 
     // ============ Constants ============
 

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -3,13 +3,20 @@ pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
 /**
  * @title UnifiedIDRegistry
  * @dev Registry contract for managing UnifiedID mappings to wallet addresses
  * @notice This contract allows a relayer to create UnifiedIDs and map them to primary wallets
+ * @notice Supports EIP-712 for typed structured data hashing and signing
  */
-contract UnifiedIDRegistry is Ownable, ReentrancyGuard {
+contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
+    // ============ Libraries ============
+    
+    using ECDSA for bytes32;
+
     // ============ State Variables ============
 
     /// @dev Mapping to determine whether an address is an active registrar authorized to create UnifiedIDs
@@ -146,7 +153,7 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard {
      * @dev Constructor to initialize the contract with an initial registrar
      * @param _initialRegistrar The address of the first registrar authorized to create UnifiedIDs
      */
-    constructor(address _initialRegistrar) Ownable(msg.sender) {
+    constructor(address _initialRegistrar) Ownable(msg.sender) EIP712("UnifiedIDRegistry", "1") {
         if (_initialRegistrar == address(0)) {
             revert InvalidRegistrarAddress();
         }
@@ -336,6 +343,15 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard {
         address wallet
     ) external view returns (string memory) {
         return walletToUnifiedId[wallet];
+    }
+
+    /**
+     * @dev Returns the EIP-712 domain separator
+     * @return The domain separator bytes32 value
+     * @notice This function exposes the domain separator for use in off-chain signature verification
+     */
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparatorV4();
     }
 
     // ============ Internal Functions ============

--- a/contracts/UnifiedIDRegistry.sol
+++ b/contracts/UnifiedIDRegistry.sol
@@ -203,6 +203,38 @@ contract UnifiedIDRegistry is Ownable, ReentrancyGuard, EIP712 {
         _createUnifiedID(unifiedId, primaryWallet);
     }
 
+    /**
+     * @dev Creates a new UnifiedID via registrar with user signature verification
+     * @param unifiedId The UnifiedID string to create
+     * @param primaryWallet The primary wallet address to associate
+     * @param signature The EIP-712 signature from primaryWallet authorizing this registration
+     * @notice Only callable by authorized registrars, requires valid user signature
+     */
+    function createUnifiedIDByRegistrar(
+        string calldata unifiedId,
+        address primaryWallet,
+        bytes calldata signature
+    ) external onlyRegistrar nonReentrant {
+        uint256 nonce = nonces[primaryWallet];
+
+        bytes32 digest = _hashUnifiedIdMessage(
+            primaryWallet,
+            unifiedId,
+            nonce
+        );
+
+        address signer = digest.recover(signature);
+        if (signer != primaryWallet) {
+            revert InvalidSignature();
+        }
+
+        // Consume nonce only on success
+        nonces[primaryWallet] = nonce + 1;
+        emit NonceConsumed(primaryWallet, nonce);
+
+        _createUnifiedID(unifiedId, primaryWallet);
+    }
+
     // ============ Registrar Management Functions ============
 
     /**

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -416,6 +416,176 @@ describe("UnifiedIDRegistry", function () {
     });
   });
 
+  // ============ SECTION 1.9: CREATE UNIFIEDID BY REGISTRAR WITH SIGNATURE ============
+  describe("createUnifiedIDByRegistrar", function () {
+    // Helper function for signing registration data
+    async function signRegistration(signer, contract, wallet, unifiedId, nonce) {
+      const network = await ethers.provider.getNetwork();
+      const domain = {
+        name: "UnifiedIDRegistry",
+        version: "1",
+        chainId: network.chainId,
+        verifyingContract: contract.address
+      };
+      
+      const types = {
+        UnifiedIdRegistration: [
+          { name: "wallet", type: "address" },
+          { name: "unifiedId", type: "string" },
+          { name: "nonce", type: "uint256" }
+        ]
+      };
+      
+      const value = { wallet, unifiedId, nonce };
+      
+      return await signer._signTypedData(domain, types, value);
+    }
+
+    it("Should successfully register with valid signature", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      expect(nonce).to.equal(0);
+
+      // Sign the registration request
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // Registrar creates UnifiedID with signature
+      await expect(
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
+      )
+        .to.emit(registry, "UnifiedIDCreated")
+        .withArgs(unifiedId, wallet, anyValue)
+        .and.to.emit(registry, "NonceConsumed")
+        .withArgs(wallet, nonce);
+
+      // Verify UnifiedID was created
+      expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(wallet);
+    });
+
+    it("Should revert with InvalidSignature when signature is from wrong wallet", async function () {
+      const { registry, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const walletToRegister = user1.address; // This is the wallet that should sign
+      const wrongWallet = user2.address; // But we'll use user2's signature
+      const nonce = await registry.getNonce(walletToRegister);
+
+      // User2 signs for user1's wallet (wrong signer)
+      const signature = await signRegistration(user2, registry, walletToRegister, unifiedId, nonce);
+
+      // Should revert because signature doesn't match wallet
+      await expect(
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, walletToRegister, signature)
+      ).to.be.revertedWithCustomError(registry, "InvalidSignature");
+    });
+
+    it("Should revert with InvalidSignature when signature is malformed", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const garbageSignature = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+      // Should revert with InvalidSignature (or potentially revert due to invalid signature format)
+      await expect(
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, garbageSignature)
+      ).to.be.reverted;
+    });
+
+    it("Should revert when called by non-registrar", async function () {
+      const { registry, user1, user2 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      // User1 signs
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // User2 (not a registrar) tries to call
+      await expect(
+        registry.connect(user2).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
+      ).to.be.revertedWithCustomError(registry, "OnlyRegistrar");
+    });
+
+    it("Should increment nonce after successful registration", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+
+      // Check initial nonce
+      expect(await registry.getNonce(wallet)).to.equal(0);
+
+      // Sign and register
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
+
+      // Nonce should be incremented
+      expect(await registry.getNonce(wallet)).to.equal(1);
+    });
+
+    it("Should emit NonceConsumed event with correct values", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      await expect(
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
+      )
+        .to.emit(registry, "NonceConsumed")
+        .withArgs(wallet, nonce);
+    });
+
+    it("Should prevent signature replay - same signature cannot be reused", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      // Sign for nonce 0
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // First registration succeeds
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
+
+      // Try to use the same signature again (should fail because nonce is now 1)
+      await expect(
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
+      ).to.be.revertedWithCustomError(registry, "InvalidSignature");
+    });
+
+    it("Should not increment nonce on failed registration", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      const invalidUnifiedId = "ab"; // Too short
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      // Sign with invalid UnifiedID
+      const signature = await signRegistration(user1, registry, wallet, invalidUnifiedId, nonce);
+
+      // Should revert due to invalid format
+      await expect(
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(invalidUnifiedId, wallet, signature)
+      ).to.be.revertedWithCustomError(registry, "UnifiedIdTooShort");
+
+      // Nonce should still be 0 (not incremented)
+      expect(await registry.getNonce(wallet)).to.equal(0);
+    });
+  });
+
   // ============ SECTION 2: REGISTRAR MANAGEMENT TESTS ============
   describe("Registrar Management - Adding Registrars", function () {
     it("Should allow owner to add registrar", async function () {

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -127,6 +127,57 @@ describe("UnifiedIDRegistry", function () {
     });
   });
 
+  // ============ SECTION 1.6: NONCE TRACKING TESTS ============
+  describe("Nonce Tracking", function () {
+    it("Should return 0 for nonces mapping on new addresses", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      // New address should have nonce of 0
+      expect(await registry.nonces(user1.address)).to.equal(0);
+      expect(await registry.getNonce(user1.address)).to.equal(0);
+    });
+
+    it("Should return correct nonce value via getNonce()", async function () {
+      const { registry, user1, user2 } = await loadFixture(deployFixture);
+
+      // Initially nonce should be 0
+      expect(await registry.getNonce(user1.address)).to.equal(0);
+      expect(await registry.getNonce(user2.address)).to.equal(0);
+
+      // Direct mapping access should match getNonce()
+      expect(await registry.nonces(user1.address)).to.equal(await registry.getNonce(user1.address));
+      expect(await registry.nonces(user2.address)).to.equal(await registry.getNonce(user2.address));
+    });
+
+    it("Should correctly form UNIFIED_ID_TYPEHASH", async function () {
+      const { registry } = await loadFixture(deployFixture);
+
+      // Get the typehash from the contract
+      const contractTypehash = await registry.getUnifiedIdTypehash();
+
+      // Compute the expected typehash in JavaScript
+      const typeString = "UnifiedIdRegistration(address wallet,string unifiedId,uint256 nonce)";
+      const expectedTypehash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(typeString));
+
+      // Compare
+      expect(contractTypehash).to.equal(expectedTypehash);
+      expect(contractTypehash).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should maintain nonce consistency across multiple queries", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const nonce1 = await registry.getNonce(user1.address);
+      const nonce2 = await registry.nonces(user1.address);
+      const nonce3 = await registry.getNonce(user1.address);
+
+      // All should be the same
+      expect(nonce1).to.equal(nonce2);
+      expect(nonce2).to.equal(nonce3);
+      expect(nonce1).to.equal(0);
+    });
+  });
+
   // ============ SECTION 2: REGISTRAR MANAGEMENT TESTS ============
   describe("Registrar Management - Adding Registrars", function () {
     it("Should allow owner to add registrar", async function () {

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -178,6 +178,67 @@ describe("UnifiedIDRegistry", function () {
     });
   });
 
+  // ============ SECTION 1.7: SIGNATURE VERIFICATION ERRORS AND EVENTS TESTS ============
+  describe("Signature Verification Errors and Events", function () {
+    it("Should have correct InvalidSignature error selector", async function () {
+      const UnifiedIDRegistry = await ethers.getContractFactory("UnifiedIDRegistry");
+      
+      // Get error selector from contract interface using getSighash
+      const errorFragment = UnifiedIDRegistry.interface.getError("InvalidSignature");
+      const errorSelector = UnifiedIDRegistry.interface.getSighash(errorFragment);
+      
+      // Compute expected selector: keccak256("InvalidSignature()") first 4 bytes
+      const expectedSelector = ethers.utils.id("InvalidSignature()").slice(0, 10); // 0x + 8 hex chars
+      
+      expect(errorSelector).to.equal(expectedSelector);
+      expect(errorSelector).to.not.equal("0x00000000");
+    });
+
+    it("Should have correct SignatureExpired error selector", async function () {
+      const UnifiedIDRegistry = await ethers.getContractFactory("UnifiedIDRegistry");
+      
+      // Get error selector from contract interface using getSighash
+      const errorFragment = UnifiedIDRegistry.interface.getError("SignatureExpired");
+      const errorSelector = UnifiedIDRegistry.interface.getSighash(errorFragment);
+      
+      // Compute expected selector: keccak256("SignatureExpired()") first 4 bytes
+      const expectedSelector = ethers.utils.id("SignatureExpired()").slice(0, 10); // 0x + 8 hex chars
+      
+      expect(errorSelector).to.equal(expectedSelector);
+      expect(errorSelector).to.not.equal("0x00000000");
+    });
+
+    it("Should have correct NonceConsumed event signature", async function () {
+      const UnifiedIDRegistry = await ethers.getContractFactory("UnifiedIDRegistry");
+      
+      // Get event from contract interface using getEventTopic
+      const eventFragment = UnifiedIDRegistry.interface.getEvent("NonceConsumed");
+      const eventTopic = UnifiedIDRegistry.interface.getEventTopic(eventFragment);
+      
+      // Compute expected topic hash: keccak256("NonceConsumed(address,uint256)")
+      const expectedTopic = ethers.utils.id("NonceConsumed(address,uint256)");
+      
+      expect(eventTopic).to.equal(expectedTopic);
+      expect(eventTopic).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should have NonceConsumed event with correct indexed parameters", async function () {
+      const UnifiedIDRegistry = await ethers.getContractFactory("UnifiedIDRegistry");
+      
+      // Get event from contract interface
+      const eventFragment = UnifiedIDRegistry.interface.getEvent("NonceConsumed");
+      
+      // Verify event has correct parameters
+      expect(eventFragment.inputs.length).to.equal(2);
+      expect(eventFragment.inputs[0].name).to.equal("wallet");
+      expect(eventFragment.inputs[0].type).to.equal("address");
+      expect(eventFragment.inputs[0].indexed).to.be.true;
+      expect(eventFragment.inputs[1].name).to.equal("nonce");
+      expect(eventFragment.inputs[1].type).to.equal("uint256");
+      expect(eventFragment.inputs[1].indexed).to.be.false;
+    });
+  });
+
   // ============ SECTION 2: REGISTRAR MANAGEMENT TESTS ============
   describe("Registrar Management - Adding Registrars", function () {
     it("Should allow owner to add registrar", async function () {

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -77,6 +77,56 @@ describe("UnifiedIDRegistry", function () {
     });
   });
 
+  // ============ SECTION 1.5: EIP-712 TESTS ============
+  describe("EIP-712 Support", function () {
+    it("Should deploy contract successfully with EIP712 initialized", async function () {
+      const { registry } = await loadFixture(deployFixture);
+
+      // Contract should deploy without errors
+      expect(registry.address).to.be.properAddress;
+      
+      // Verify EIP712 is initialized by checking domain separator is accessible
+      const domainSeparator = await registry.domainSeparator();
+      expect(domainSeparator).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should return non-zero domain separator", async function () {
+      const { registry } = await loadFixture(deployFixture);
+
+      const domainSeparator = await registry.domainSeparator();
+      
+      // Domain separator should be a non-zero bytes32 value
+      expect(domainSeparator).to.not.equal(ethers.constants.HashZero);
+      expect(domainSeparator.length).to.equal(66); // 0x + 64 hex characters
+    });
+
+    it("Should maintain consistent domain separator across calls", async function () {
+      const { registry } = await loadFixture(deployFixture);
+
+      const domainSeparator1 = await registry.domainSeparator();
+      const domainSeparator2 = await registry.domainSeparator();
+      
+      // Domain separator should be consistent
+      expect(domainSeparator1).to.equal(domainSeparator2);
+    });
+
+    it("Should allow createUnifiedID to work after EIP712 integration", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
+
+      // Verify EIP712 is initialized
+      const domainSeparator = await registry.domainSeparator();
+      expect(domainSeparator).to.not.equal(ethers.constants.HashZero);
+
+      // Verify existing functionality still works
+      const unifiedId = "testuser123";
+      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+
+      expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(user1.address);
+      expect(await registry.totalIDs()).to.equal(1);
+    });
+  });
+
   // ============ SECTION 2: REGISTRAR MANAGEMENT TESTS ============
   describe("Registrar Management - Adding Registrars", function () {
     it("Should allow owner to add registrar", async function () {

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -239,6 +239,183 @@ describe("UnifiedIDRegistry", function () {
     });
   });
 
+  // ============ SECTION 1.8: EIP-712 HASH HELPER TESTS ============
+  describe("EIP-712 Hash Helper Functions", function () {
+    // Helper function for signing registration data
+    async function signRegistration(signer, contract, wallet, unifiedId, nonce) {
+      const network = await ethers.provider.getNetwork();
+      const domain = {
+        name: "UnifiedIDRegistry",
+        version: "1",
+        chainId: network.chainId,
+        verifyingContract: contract.address
+      };
+      
+      const types = {
+        UnifiedIdRegistration: [
+          { name: "wallet", type: "address" },
+          { name: "unifiedId", type: "string" },
+          { name: "nonce", type: "uint256" }
+        ]
+      };
+      
+      const value = { wallet, unifiedId, nonce };
+      
+      return await signer._signTypedData(domain, types, value);
+    }
+
+    it("Should return consistent hash for same inputs", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const wallet = user1.address;
+      const unifiedId = "testuser123";
+      const nonce = 0;
+
+      const hash1 = await registry.getRegistrationHash(wallet, unifiedId, nonce);
+      const hash2 = await registry.getRegistrationHash(wallet, unifiedId, nonce);
+      const hash3 = await registry.getRegistrationHash(wallet, unifiedId, nonce);
+
+      expect(hash1).to.equal(hash2);
+      expect(hash2).to.equal(hash3);
+      expect(hash1).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should return different hash when wallet changes", async function () {
+      const { registry, user1, user2 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const nonce = 0;
+
+      const hash1 = await registry.getRegistrationHash(user1.address, unifiedId, nonce);
+      const hash2 = await registry.getRegistrationHash(user2.address, unifiedId, nonce);
+
+      expect(hash1).to.not.equal(hash2);
+      expect(hash1).to.not.equal(ethers.constants.HashZero);
+      expect(hash2).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should return different hash when unifiedId changes", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const wallet = user1.address;
+      const nonce = 0;
+
+      const hash1 = await registry.getRegistrationHash(wallet, "testuser123", nonce);
+      const hash2 = await registry.getRegistrationHash(wallet, "testuser456", nonce);
+      const hash3 = await registry.getRegistrationHash(wallet, "differentid", nonce);
+
+      expect(hash1).to.not.equal(hash2);
+      expect(hash2).to.not.equal(hash3);
+      expect(hash1).to.not.equal(hash3);
+      expect(hash1).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should return different hash when nonce changes", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const wallet = user1.address;
+      const unifiedId = "testuser123";
+
+      const hash1 = await registry.getRegistrationHash(wallet, unifiedId, 0);
+      const hash2 = await registry.getRegistrationHash(wallet, unifiedId, 1);
+      const hash3 = await registry.getRegistrationHash(wallet, unifiedId, 2);
+
+      expect(hash1).to.not.equal(hash2);
+      expect(hash2).to.not.equal(hash3);
+      expect(hash1).to.not.equal(hash3);
+      expect(hash1).to.not.equal(ethers.constants.HashZero);
+    });
+
+    it("Should match hash computed by signTypedData and verify recovered address", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const wallet = user1.address;
+      const unifiedId = "testuser123";
+      const nonce = 0;
+
+      // Get hash from contract (this is the final hash that should be signed)
+      const contractHash = await registry.getRegistrationHash(wallet, unifiedId, nonce);
+
+      // Sign using signTypedData - ethers.js will compute the same hash internally
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // Parse signature
+      const sig = ethers.utils.splitSignature(signature);
+      
+      // The contract hash is already the final EIP-712 hash (includes prefix)
+      // So we can recover directly from it
+      const recoveredAddress = ethers.utils.recoverAddress(
+        contractHash,
+        { r: sig.r, s: sig.s, v: sig.v }
+      );
+
+      expect(recoveredAddress).to.equal(wallet);
+      
+      // Also verify that the hash matches what ethers computes
+      const network = await ethers.provider.getNetwork();
+      const domain = {
+        name: "UnifiedIDRegistry",
+        version: "1",
+        chainId: network.chainId,
+        verifyingContract: registry.address
+      };
+      
+      const types = {
+        UnifiedIdRegistration: [
+          { name: "wallet", type: "address" },
+          { name: "unifiedId", type: "string" },
+          { name: "nonce", type: "uint256" }
+        ]
+      };
+      
+      const value = { wallet, unifiedId, nonce };
+      
+      // Compute hash using ethers (for verification)
+      const ethersHash = ethers.utils._TypedDataEncoder.hash(domain, types, value);
+      expect(contractHash).to.equal(ethersHash);
+    });
+
+    it("Should produce hash that can be verified with ECDSA.recover", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const wallet = user1.address;
+      const unifiedId = "testuser123";
+      const nonce = 0;
+
+      // Get hash from contract
+      const contractHash = await registry.getRegistrationHash(wallet, unifiedId, nonce);
+
+      // Sign the hash directly (not EIP-712 format)
+      const messageHash = ethers.utils.arrayify(contractHash);
+      const signature = await user1.signMessage(messageHash);
+
+      // Recover address
+      const recoveredAddress = ethers.utils.verifyMessage(messageHash, signature);
+
+      expect(recoveredAddress).to.equal(wallet);
+    });
+
+    it("Should produce different hashes for different contract addresses", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+      
+      // Deploy a second instance
+      const [owner, initialRegistrar] = await ethers.getSigners();
+      const UnifiedIDRegistry = await ethers.getContractFactory("UnifiedIDRegistry");
+      const registry2 = await UnifiedIDRegistry.deploy(initialRegistrar.address);
+      await registry2.deployed();
+
+      const wallet = user1.address;
+      const unifiedId = "testuser123";
+      const nonce = 0;
+
+      const hash1 = await registry.getRegistrationHash(wallet, unifiedId, nonce);
+      const hash2 = await registry2.getRegistrationHash(wallet, unifiedId, nonce);
+
+      // Hashes should be different because domain separator includes contract address
+      expect(hash1).to.not.equal(hash2);
+    });
+  });
+
   // ============ SECTION 2: REGISTRAR MANAGEMENT TESTS ============
   describe("Registrar Management - Adding Registrars", function () {
     it("Should allow owner to add registrar", async function () {

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -25,8 +25,7 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar } = await loadFixture(deployFixture);
 
       expect(await registry.isRegistrar(initialRegistrar.address)).to.be.true;
-      const registrars = await registry.getRegistrars();
-      expect(registrars).to.include(initialRegistrar.address);
+      expect(await registry.getRegistrarCount()).to.equal(1);
     });
 
     it("Should set registrarCount to 1 after deployment", async function () {
@@ -827,19 +826,6 @@ describe("UnifiedIDRegistry", function () {
       expect(await registry.isRegistrar(user3.address)).to.be.true;
     });
 
-    it("Should return correct array from getRegistrars", async function () {
-      const { registry, owner, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
-
-      await registry.connect(owner).addRegistrar(user1.address);
-      await registry.connect(owner).addRegistrar(user2.address);
-
-      const registrars = await registry.getRegistrars();
-      expect(registrars.length).to.equal(3);
-      expect(registrars).to.include(initialRegistrar.address);
-      expect(registrars).to.include(user1.address);
-      expect(registrars).to.include(user2.address);
-    });
-
     it("Should return true for isRegistrar when registrar is added", async function () {
       const { registry, owner, user1 } = await loadFixture(deployFixture);
 
@@ -906,24 +892,6 @@ describe("UnifiedIDRegistry", function () {
       await registry.connect(owner).removeRegistrar(initialRegistrar.address);
 
       expect(await registry.isRegistrar(initialRegistrar.address)).to.be.false;
-    });
-
-    it("Should return updated array from getRegistrars after removal", async function () {
-      const { registry, owner, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
-
-      await registry.connect(owner).addRegistrar(user1.address);
-      await registry.connect(owner).addRegistrar(user2.address);
-
-      let registrars = await registry.getRegistrars();
-      expect(registrars.length).to.equal(3);
-
-      await registry.connect(owner).removeRegistrar(initialRegistrar.address);
-
-      registrars = await registry.getRegistrars();
-      expect(registrars.length).to.equal(2);
-      expect(registrars).to.not.include(initialRegistrar.address);
-      expect(registrars).to.include(user1.address);
-      expect(registrars).to.include(user2.address);
     });
 
     it("Should allow removing and re-adding same registrar", async function () {
@@ -1129,19 +1097,6 @@ describe("UnifiedIDRegistry", function () {
 
   // ============ SECTION 4: VIEW FUNCTIONS TESTS ============
   describe("View Functions", function () {
-    it("Should return all registrars from getRegistrars", async function () {
-      const { registry, owner, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
-
-      await registry.connect(owner).addRegistrar(user1.address);
-      await registry.connect(owner).addRegistrar(user2.address);
-
-      const registrars = await registry.getRegistrars();
-      expect(registrars.length).to.equal(3);
-      expect(registrars).to.include(initialRegistrar.address);
-      expect(registrars).to.include(user1.address);
-      expect(registrars).to.include(user2.address);
-    });
-
     it("Should return correct count from getRegistrarCount", async function () {
       const { registry, owner, user1, user2 } = await loadFixture(deployFixture);
 
@@ -1292,22 +1247,19 @@ describe("UnifiedIDRegistry", function () {
       expect(await registry.registrarCount()).to.equal(1);
     });
 
-    it("Should maintain correct registrar array order after removals", async function () {
+    it("Should maintain correct registrar state after removals", async function () {
       const { registry, owner, initialRegistrar, user1, user2, user3 } = await loadFixture(deployFixture);
 
       await registry.connect(owner).addRegistrar(user1.address);
       await registry.connect(owner).addRegistrar(user2.address);
       await registry.connect(owner).addRegistrar(user3.address);
 
+      expect(await registry.getRegistrarCount()).to.equal(4);
+
       // Remove middle registrar (user2)
       await registry.connect(owner).removeRegistrar(user2.address);
 
-      const registrars = await registry.getRegistrars();
-      expect(registrars.length).to.equal(3);
-      expect(registrars).to.include(initialRegistrar.address);
-      expect(registrars).to.include(user1.address);
-      expect(registrars).to.include(user3.address);
-      expect(registrars).to.not.include(user2.address);
+      expect(await registry.getRegistrarCount()).to.equal(3);
 
       // Verify all remaining are still registrars
       expect(await registry.isRegistrar(initialRegistrar.address)).to.be.true;
@@ -1322,10 +1274,8 @@ describe("UnifiedIDRegistry", function () {
       await registry.connect(owner).removeRegistrar(initialRegistrar.address);
 
       expect(await registry.registrarCount()).to.equal(0);
+      expect(await registry.getRegistrarCount()).to.equal(0);
       expect(await registry.isRegistrar(initialRegistrar.address)).to.be.false;
-
-      const registrars = await registry.getRegistrars();
-      expect(registrars.length).to.equal(0);
     });
   });
 

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -4,6 +4,29 @@ const { loadFixture } = require("@nomicfoundation/hardhat-toolbox/network-helper
 const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const { deployFixture } = require("./fixtures/deploy");
 
+// Global helper function for signing registration data
+async function signRegistration(signer, contract, wallet, unifiedId, nonce) {
+  const network = await ethers.provider.getNetwork();
+  const domain = {
+    name: "UnifiedIDRegistry",
+    version: "1",
+    chainId: network.chainId,
+    verifyingContract: contract.address
+  };
+  
+  const types = {
+    UnifiedIdRegistration: [
+      { name: "wallet", type: "address" },
+      { name: "unifiedId", type: "string" },
+      { name: "nonce", type: "uint256" }
+    ]
+  };
+  
+  const value = { wallet, unifiedId, nonce };
+  
+  return await signer._signTypedData(domain, types, value);
+}
+
 describe("UnifiedIDRegistry", function () {
   // ============ SECTION 1: DEPLOYMENT TESTS ============
   describe("Deployment", function () {
@@ -109,19 +132,23 @@ describe("UnifiedIDRegistry", function () {
       expect(domainSeparator1).to.equal(domainSeparator2);
     });
 
-    it("Should allow createUnifiedID to work after EIP712 integration", async function () {
+    it("Should allow signature-based registration to work after EIP712 integration", async function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       // Verify EIP712 is initialized
       const domainSeparator = await registry.domainSeparator();
       expect(domainSeparator).to.not.equal(ethers.constants.HashZero);
 
-      // Verify existing functionality still works
+      // Verify existing functionality still works with signature-based registration
       const unifiedId = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
 
       expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
-      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(user1.address);
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(wallet);
       expect(await registry.totalIDs()).to.equal(1);
     });
   });
@@ -929,10 +956,18 @@ describe("UnifiedIDRegistry", function () {
       await registry.connect(owner).addRegistrar(user1.address);
       await registry.connect(owner).addRegistrar(user2.address);
 
-      // Create IDs with different registrars
-      await registry.connect(initialRegistrar).createUnifiedID("id01", user1.address);
-      await registry.connect(user1).createUnifiedID("id02", user2.address);
-      await registry.connect(user2).createUnifiedID("id03", user3.address);
+      // Create IDs with different registrars (users sign for themselves)
+      const nonce1 = await registry.getNonce(user1.address);
+      const signature1 = await signRegistration(user1, registry, user1.address, "id01", nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id01", user1.address, signature1);
+
+      const nonce2 = await registry.getNonce(user2.address);
+      const signature2 = await signRegistration(user2, registry, user2.address, "id02", nonce2);
+      await registry.connect(user1).createUnifiedIDByRegistrar("id02", user2.address, signature2);
+
+      const nonce3 = await registry.getNonce(user3.address);
+      const signature3 = await signRegistration(user3, registry, user3.address, "id03", nonce3);
+      await registry.connect(user2).createUnifiedIDByRegistrar("id03", user3.address, signature3);
 
       expect(await registry.unifiedIdExists("id01")).to.be.true;
       expect(await registry.unifiedIdExists("id02")).to.be.true;
@@ -958,14 +993,30 @@ describe("UnifiedIDRegistry", function () {
 
   // ============ SECTION 3: UNIFIEDID CREATION TESTS (with registrars) ============
   describe("UnifiedID Creation - With Registrars", function () {
-    it("Should allow registrar to create UnifiedID", async function () {
+    it("Should verify legacy createUnifiedID function no longer exists", async function () {
+      const { registry } = await loadFixture(deployFixture);
+      
+      // Verify createUnifiedID function is not available
+      const contractInterface = registry.interface;
+      const functionNames = Object.keys(contractInterface.functions);
+      
+      expect(functionNames).to.not.include("createUnifiedID(string,address)");
+      expect(functionNames).to.include("createUnifiedIDByRegistrar(string,address,bytes)");
+      expect(functionNames).to.include("createUnifiedIDSelf(string,bytes)");
+    });
+
+    it("Should allow registrar to create UnifiedID with signature", async function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
 
       expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
-      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(user1.address);
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(wallet);
     });
 
     it("Should allow multiple registrars to create different UnifiedIDs", async function () {
@@ -973,8 +1024,15 @@ describe("UnifiedIDRegistry", function () {
 
       await registry.connect(owner).addRegistrar(user1.address);
 
-      await registry.connect(initialRegistrar).createUnifiedID("id01", user2.address);
-      await registry.connect(user1).createUnifiedID("id02", user3.address);
+      // User2 signs for id01
+      const nonce1 = await registry.getNonce(user2.address);
+      const signature1 = await signRegistration(user2, registry, user2.address, "id01", nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id01", user2.address, signature1);
+
+      // User3 signs for id02
+      const nonce2 = await registry.getNonce(user3.address);
+      const signature2 = await signRegistration(user3, registry, user3.address, "id02", nonce2);
+      await registry.connect(user1).createUnifiedIDByRegistrar("id02", user3.address, signature2);
 
       expect(await registry.unifiedIdExists("id01")).to.be.true;
       expect(await registry.unifiedIdExists("id02")).to.be.true;
@@ -986,8 +1044,12 @@ describe("UnifiedIDRegistry", function () {
       const { registry, user1, user2 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
+      const wallet = user2.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user2, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(user1).createUnifiedID(unifiedId, user2.address)
+        registry.connect(user1).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       ).to.be.revertedWithCustomError(registry, "OnlyRegistrar");
     });
 
@@ -995,19 +1057,27 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       )
         .to.emit(registry, "UnifiedIDCreated")
-        .withArgs(unifiedId, user1.address, anyValue);
+        .withArgs(unifiedId, wallet, anyValue);
     });
 
     it("Should still validate UnifiedID length (too short)", async function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "ab";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       ).to.be.revertedWithCustomError(registry, "UnifiedIdTooShort");
     });
 
@@ -1015,8 +1085,12 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "a".repeat(33);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       ).to.be.revertedWithCustomError(registry, "UnifiedIdTooLong");
     });
 
@@ -1024,8 +1098,12 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "TestUser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       ).to.be.revertedWithCustomError(registry, "InvalidUnifiedIdFormat");
     });
 
@@ -1033,8 +1111,12 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "test@user123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       ).to.be.revertedWithCustomError(registry, "InvalidUnifiedIdFormat");
     });
 
@@ -1042,31 +1124,52 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet1 = user1.address;
+      const nonce1 = await registry.getNonce(wallet1);
+      const signature1 = await signRegistration(user1, registry, wallet1, unifiedId, nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet1, signature1);
 
+      const wallet2 = user2.address;
+      const nonce2 = await registry.getNonce(wallet2);
+      const signature2 = await signRegistration(user2, registry, wallet2, unifiedId, nonce2);
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, user2.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet2, signature2)
       ).to.be.revertedWithCustomError(registry, "UnifiedIdAlreadyTaken");
     });
 
-    it("Should still prevent zero address as primary wallet", async function () {
-      const { registry, initialRegistrar } = await loadFixture(deployFixture);
+    it("Should prevent zero address as primary wallet (signature verification prevents it)", async function () {
+      const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
+      // Try with zero address - signature verification happens first
+      // Since signature is for user1.address but we pass zero address, it will fail at signature verification
+      // Zero address validation still exists in _createUnifiedID but is protected by signature verification
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId, ethers.constants.AddressZero)
-      ).to.be.revertedWithCustomError(registry, "InvalidPrimaryWallet");
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, ethers.constants.AddressZero, signature)
+      ).to.be.revertedWithCustomError(registry, "InvalidSignature");
+      
+      // Note: Zero address validation is enforced in _createUnifiedID, but signature verification
+      // prevents reaching that check since zero address cannot sign
     });
 
     it("Should still prevent wallet from having multiple UnifiedIDs", async function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId1 = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId1, user1.address);
+      const wallet = user1.address;
+      const nonce1 = await registry.getNonce(wallet);
+      const signature1 = await signRegistration(user1, registry, wallet, unifiedId1, nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId1, wallet, signature1);
 
       const unifiedId2 = "testuser456";
+      const nonce2 = await registry.getNonce(wallet);
+      const signature2 = await signRegistration(user1, registry, wallet, unifiedId2, nonce2);
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID(unifiedId2, user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId2, wallet, signature2)
       ).to.be.revertedWithCustomError(registry, "WalletAlreadyHasId");
     });
 
@@ -1075,22 +1178,33 @@ describe("UnifiedIDRegistry", function () {
 
       expect(await registry.totalIDs()).to.equal(0);
 
-      await registry.connect(initialRegistrar).createUnifiedID("user1", user1.address);
+      const wallet1 = user1.address;
+      const nonce1 = await registry.getNonce(wallet1);
+      const signature1 = await signRegistration(user1, registry, wallet1, "user1", nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("user1", wallet1, signature1);
       expect(await registry.totalIDs()).to.equal(1);
 
-      await registry.connect(initialRegistrar).createUnifiedID("user2", user2.address);
+      const wallet2 = user2.address;
+      const nonce2 = await registry.getNonce(wallet2);
+      const signature2 = await signRegistration(user2, registry, wallet2, "user2", nonce2);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("user2", wallet2, signature2);
       expect(await registry.totalIDs()).to.equal(2);
     });
 
     it("Should prevent removed registrar from creating UnifiedIDs", async function () {
-      const { registry, owner, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
+      const { registry, owner, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       // Remove registrar
       await registry.connect(owner).removeRegistrar(initialRegistrar.address);
 
       // Should not be able to create ID
+      const unifiedId = "testid";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      
       await expect(
-        registry.connect(initialRegistrar).createUnifiedID("testid", user1.address)
+        registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature)
       ).to.be.revertedWithCustomError(registry, "OnlyRegistrar");
     });
   });
@@ -1125,12 +1239,15 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
-      const tx = await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      const tx = await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
       const receipt = await tx.wait();
       const block = await ethers.provider.getBlock(receipt.blockNumber);
 
       const unifiedIDData = await registry.getUnifiedID(unifiedId);
-      expect(unifiedIDData.primaryWallet).to.equal(user1.address);
+      expect(unifiedIDData.primaryWallet).to.equal(wallet);
       expect(unifiedIDData.createdAt).to.equal(block.timestamp);
     });
 
@@ -1147,7 +1264,10 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
 
       expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
     });
@@ -1163,9 +1283,12 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
 
-      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(user1.address);
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(wallet);
     });
 
     it("Should revert getPrimaryWallet if UnifiedID does not exist", async function () {
@@ -1181,9 +1304,12 @@ describe("UnifiedIDRegistry", function () {
       const { registry, initialRegistrar, user1 } = await loadFixture(deployFixture);
 
       const unifiedId = "testuser123";
-      await registry.connect(initialRegistrar).createUnifiedID(unifiedId, user1.address);
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar(unifiedId, wallet, signature);
 
-      expect(await registry.getUnifiedIdByWallet(user1.address)).to.equal(unifiedId);
+      expect(await registry.getUnifiedIdByWallet(wallet)).to.equal(unifiedId);
     });
 
     it("Should return empty string from getUnifiedIdByWallet when wallet has no ID", async function () {
@@ -1291,9 +1417,17 @@ describe("UnifiedIDRegistry", function () {
       expect(await registry.registrarCount()).to.equal(3);
 
       // Step 2: Create IDs with different registrars
-      await registry.connect(initialRegistrar).createUnifiedID("id01", user1.address);
-      await registry.connect(user1).createUnifiedID("id02", user2.address);
-      await registry.connect(user2).createUnifiedID("id03", user3.address);
+      const nonce1 = await registry.getNonce(user1.address);
+      const signature1 = await signRegistration(user1, registry, user1.address, "id01", nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id01", user1.address, signature1);
+
+      const nonce2 = await registry.getNonce(user2.address);
+      const signature2 = await signRegistration(user2, registry, user2.address, "id02", nonce2);
+      await registry.connect(user1).createUnifiedIDByRegistrar("id02", user2.address, signature2);
+
+      const nonce3 = await registry.getNonce(user3.address);
+      const signature3 = await signRegistration(user3, registry, user3.address, "id03", nonce3);
+      await registry.connect(user2).createUnifiedIDByRegistrar("id03", user3.address, signature3);
 
       expect(await registry.totalIDs()).to.equal(3);
       expect(await registry.unifiedIdExists("id01")).to.be.true;
@@ -1307,8 +1441,10 @@ describe("UnifiedIDRegistry", function () {
       expect(await registry.isRegistrar(user1.address)).to.be.false;
 
       // Step 4: Verify removed registrar cannot create new IDs
+      const nonce4 = await registry.getNonce(user3.address);
+      const signature4 = await signRegistration(user3, registry, user3.address, "id04", nonce4);
       await expect(
-        registry.connect(user1).createUnifiedID("id04", user3.address)
+        registry.connect(user1).createUnifiedIDByRegistrar("id04", user3.address, signature4)
       ).to.be.revertedWithCustomError(registry, "OnlyRegistrar");
 
       // Step 5: Verify other registrars can still create IDs
@@ -1317,8 +1453,13 @@ describe("UnifiedIDRegistry", function () {
       const newWallet1 = signers[5];
       const newWallet2 = signers[6];
       
-      await registry.connect(initialRegistrar).createUnifiedID("id05", newWallet1.address);
-      await registry.connect(user2).createUnifiedID("id06", newWallet2.address);
+      const nonce5 = await registry.getNonce(newWallet1.address);
+      const signature5 = await signRegistration(newWallet1, registry, newWallet1.address, "id05", nonce5);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id05", newWallet1.address, signature5);
+
+      const nonce6 = await registry.getNonce(newWallet2.address);
+      const signature6 = await signRegistration(newWallet2, registry, newWallet2.address, "id06", nonce6);
+      await registry.connect(user2).createUnifiedIDByRegistrar("id06", newWallet2.address, signature6);
 
       expect(await registry.totalIDs()).to.equal(5);
     });
@@ -1329,8 +1470,10 @@ describe("UnifiedIDRegistry", function () {
       // Owner adds registrar
       await registry.connect(owner).addRegistrar(user1.address);
 
-      // Registrar creates ID
-      await registry.connect(initialRegistrar).createUnifiedID("id01", user2.address);
+      // Registrar creates ID with signature
+      const nonce = await registry.getNonce(user2.address);
+      const signature = await signRegistration(user2, registry, user2.address, "id01", nonce);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id01", user2.address, signature);
 
       // Owner removes registrar
       await registry.connect(owner).removeRegistrar(user1.address);
@@ -1343,8 +1486,11 @@ describe("UnifiedIDRegistry", function () {
     it("Should not interfere registrar operations with view functions", async function () {
       const { registry, owner, initialRegistrar, user1, user2 } = await loadFixture(deployFixture);
 
-      // Create ID
-      await registry.connect(initialRegistrar).createUnifiedID("id01", user1.address);
+      // Create ID with signature
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, "id01", nonce);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id01", wallet, signature);
 
       // Add/remove registrars
       await registry.connect(owner).addRegistrar(user2.address);
@@ -1352,11 +1498,11 @@ describe("UnifiedIDRegistry", function () {
 
       // View functions should still work
       expect(await registry.unifiedIdExists("id01")).to.be.true;
-      expect(await registry.getPrimaryWallet("id01")).to.equal(user1.address);
-      expect(await registry.getUnifiedIdByWallet(user1.address)).to.equal("id01");
+      expect(await registry.getPrimaryWallet("id01")).to.equal(wallet);
+      expect(await registry.getUnifiedIdByWallet(wallet)).to.equal("id01");
 
       const unifiedIDData = await registry.getUnifiedID("id01");
-      expect(unifiedIDData.primaryWallet).to.equal(user1.address);
+      expect(unifiedIDData.primaryWallet).to.equal(wallet);
     });
 
     it("Should handle complex scenario with multiple registrars creating and removing", async function () {
@@ -1377,11 +1523,22 @@ describe("UnifiedIDRegistry", function () {
       const wallet6 = signers[10];
       const wallet7 = signers[11];
 
-      // Each registrar creates an ID
-      await registry.connect(initialRegistrar).createUnifiedID("id01", wallet1.address);
-      await registry.connect(user1).createUnifiedID("id02", wallet2.address);
-      await registry.connect(user2).createUnifiedID("id03", wallet3.address);
-      await registry.connect(user3).createUnifiedID("id04", wallet4.address);
+      // Each registrar creates an ID with signatures
+      const nonce1 = await registry.getNonce(wallet1.address);
+      const signature1 = await signRegistration(wallet1, registry, wallet1.address, "id01", nonce1);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id01", wallet1.address, signature1);
+
+      const nonce2 = await registry.getNonce(wallet2.address);
+      const signature2 = await signRegistration(wallet2, registry, wallet2.address, "id02", nonce2);
+      await registry.connect(user1).createUnifiedIDByRegistrar("id02", wallet2.address, signature2);
+
+      const nonce3 = await registry.getNonce(wallet3.address);
+      const signature3 = await signRegistration(wallet3, registry, wallet3.address, "id03", nonce3);
+      await registry.connect(user2).createUnifiedIDByRegistrar("id03", wallet3.address, signature3);
+
+      const nonce4 = await registry.getNonce(wallet4.address);
+      const signature4 = await signRegistration(wallet4, registry, wallet4.address, "id04", nonce4);
+      await registry.connect(user3).createUnifiedIDByRegistrar("id04", wallet4.address, signature4);
 
       expect(await registry.totalIDs()).to.equal(4);
 
@@ -1389,9 +1546,17 @@ describe("UnifiedIDRegistry", function () {
       await registry.connect(owner).removeRegistrar(user2.address);
 
       // Remaining registrars should still work
-      await registry.connect(initialRegistrar).createUnifiedID("id05", wallet5.address);
-      await registry.connect(user1).createUnifiedID("id06", wallet6.address);
-      await registry.connect(user3).createUnifiedID("id07", wallet7.address);
+      const nonce5 = await registry.getNonce(wallet5.address);
+      const signature5 = await signRegistration(wallet5, registry, wallet5.address, "id05", nonce5);
+      await registry.connect(initialRegistrar).createUnifiedIDByRegistrar("id05", wallet5.address, signature5);
+
+      const nonce6 = await registry.getNonce(wallet6.address);
+      const signature6 = await signRegistration(wallet6, registry, wallet6.address, "id06", nonce6);
+      await registry.connect(user1).createUnifiedIDByRegistrar("id06", wallet6.address, signature6);
+
+      const nonce7 = await registry.getNonce(wallet7.address);
+      const signature7 = await signRegistration(wallet7, registry, wallet7.address, "id07", nonce7);
+      await registry.connect(user3).createUnifiedIDByRegistrar("id07", wallet7.address, signature7);
 
       expect(await registry.totalIDs()).to.equal(7);
 

--- a/test/UnifiedIDRegistry.test.js
+++ b/test/UnifiedIDRegistry.test.js
@@ -586,6 +586,179 @@ describe("UnifiedIDRegistry", function () {
     });
   });
 
+  // ============ SECTION 1.10: CREATE UNIFIEDID SELF ============
+  describe("createUnifiedIDSelf", function () {
+    // Helper function for signing registration data (reuse from previous section)
+    async function signRegistration(signer, contract, wallet, unifiedId, nonce) {
+      const network = await ethers.provider.getNetwork();
+      const domain = {
+        name: "UnifiedIDRegistry",
+        version: "1",
+        chainId: network.chainId,
+        verifyingContract: contract.address
+      };
+      
+      const types = {
+        UnifiedIdRegistration: [
+          { name: "wallet", type: "address" },
+          { name: "unifiedId", type: "string" },
+          { name: "nonce", type: "uint256" }
+        ]
+      };
+      
+      const value = { wallet, unifiedId, nonce };
+      
+      return await signer._signTypedData(domain, types, value);
+    }
+
+    it("Should successfully register with valid signature", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+      expect(nonce).to.equal(0);
+
+      // Sign the registration request
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // User creates UnifiedID themselves with signature
+      await expect(
+        registry.connect(user1).createUnifiedIDSelf(unifiedId, signature)
+      )
+        .to.emit(registry, "UnifiedIDCreated")
+        .withArgs(unifiedId, wallet, anyValue)
+        .and.to.emit(registry, "NonceConsumed")
+        .withArgs(wallet, nonce);
+
+      // Verify UnifiedID was created
+      expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(wallet);
+    });
+
+    it("Should revert with InvalidSignature when signature is from different wallet", async function () {
+      const { registry, user1, user2 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet1 = user1.address;
+      const wallet2 = user2.address;
+      const nonce = await registry.getNonce(wallet1);
+
+      // User1 signs for themselves
+      const signature = await signRegistration(user1, registry, wallet1, unifiedId, nonce);
+
+      // User2 tries to use user1's signature (msg.sender = user2, but sig is from user1)
+      await expect(
+        registry.connect(user2).createUnifiedIDSelf(unifiedId, signature)
+      ).to.be.revertedWithCustomError(registry, "InvalidSignature");
+    });
+
+    it("Should revert with InvalidSignature when signature is malformed", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const garbageSignature = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+      // Should revert with InvalidSignature (or potentially revert due to invalid signature format)
+      await expect(
+        registry.connect(user1).createUnifiedIDSelf(unifiedId, garbageSignature)
+      ).to.be.reverted;
+    });
+
+    it("Should allow any address to call (no registrar restriction)", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      // User1 signs
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // User1 (not a registrar) calls directly - should succeed
+      await registry.connect(user1).createUnifiedIDSelf(unifiedId, signature);
+
+      // Verify UnifiedID was created
+      expect(await registry.unifiedIdExists(unifiedId)).to.be.true;
+      expect(await registry.getPrimaryWallet(unifiedId)).to.equal(wallet);
+    });
+
+    it("Should increment nonce after successful registration", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+
+      // Check initial nonce
+      expect(await registry.getNonce(wallet)).to.equal(0);
+
+      // Sign and register
+      const nonce = await registry.getNonce(wallet);
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      await registry.connect(user1).createUnifiedIDSelf(unifiedId, signature);
+
+      // Nonce should be incremented
+      expect(await registry.getNonce(wallet)).to.equal(1);
+    });
+
+    it("Should emit NonceConsumed event with correct values", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      await expect(
+        registry.connect(user1).createUnifiedIDSelf(unifiedId, signature)
+      )
+        .to.emit(registry, "NonceConsumed")
+        .withArgs(wallet, nonce);
+    });
+
+    it("Should prevent signature replay - same signature cannot be reused", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId = "testuser123";
+      const wallet = user1.address;
+      const nonce = await registry.getNonce(wallet);
+
+      // Sign for nonce 0
+      const signature = await signRegistration(user1, registry, wallet, unifiedId, nonce);
+
+      // First registration succeeds
+      await registry.connect(user1).createUnifiedIDSelf(unifiedId, signature);
+
+      // Try to use the same signature again (should fail because nonce is now 1)
+      await expect(
+        registry.connect(user1).createUnifiedIDSelf(unifiedId, signature)
+      ).to.be.revertedWithCustomError(registry, "InvalidSignature");
+    });
+
+    it("Should prevent user from registering if wallet already has UnifiedID", async function () {
+      const { registry, user1 } = await loadFixture(deployFixture);
+
+      const unifiedId1 = "testid1";
+      const unifiedId2 = "testid2";
+      const wallet = user1.address;
+
+      // Register first UnifiedID
+      const nonce1 = await registry.getNonce(wallet);
+      const signature1 = await signRegistration(user1, registry, wallet, unifiedId1, nonce1);
+      await registry.connect(user1).createUnifiedIDSelf(unifiedId1, signature1);
+
+      // Try to register second UnifiedID (should fail)
+      const nonce2 = await registry.getNonce(wallet);
+      const signature2 = await signRegistration(user1, registry, wallet, unifiedId2, nonce2);
+      
+      await expect(
+        registry.connect(user1).createUnifiedIDSelf(unifiedId2, signature2)
+      ).to.be.revertedWithCustomError(registry, "WalletAlreadyHasId");
+    });
+  });
+
   // ============ SECTION 2: REGISTRAR MANAGEMENT TESTS ============
   describe("Registrar Management - Adding Registrars", function () {
     it("Should allow owner to add registrar", async function () {


### PR DESCRIPTION
Summary
This upgrade introduces mandatory EIP-712 signature verification for all UnifiedID registrations.

Issues Implemented
- 1: Add EIP-712 Infrastructure
- 2: Add Nonce Tracking and Typehash
- 3: Add Custom Errors and Events
- 4: Create Internal EIP-712 Hash Function
- 5: Refactor Core Registration Logic
- 6: Implement Registrar Registration with Signature
- 7: Implement Self-Registration with Signature
- 8: Simplify Registrar Storage
- 9: Remove Legacy createUnifiedID Function
